### PR TITLE
Add code to measure trigger efficiencies

### DIFF
--- a/CMGTools/H2TauTau/cfgPython/mt/tauMu_2015_trigg_cfg.py
+++ b/CMGTools/H2TauTau/cfgPython/mt/tauMu_2015_trigg_cfg.py
@@ -22,7 +22,7 @@ from CMGTools.H2TauTau.htt_ntuple_base_cff import puFileData, puFileMC, eventSel
 # production = True run on batch, production = False (or unset) run locally
 production = getHeppyOption('production')
 
-pick_events = True
+pick_events = False
 syncntuple = False
 
 creator = ComponentCreator()
@@ -110,13 +110,13 @@ for i, module in enumerate(sequence):
   
     if module.name == 'TriggerAnalyzer':
         module.requireTrigger = True
-        module.extraTrig = ['HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v1']
+        module.extraTrig = ['HLT_IsoMu17_eta2p1_LooseIsoPFTau20_v1']
+        # module.extraTrig = ['HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v1']
         # module.verbose = False
         module.saveFlag = True
     
     if module.name == 'H2TauTauTreeProducerTauMu':
-        sequence.insert(i, treeProducer)
-        del sequence[i+1]
+        module.addTnPInfo = True
 
 print sequence
 

--- a/CMGTools/H2TauTau/cfgPython/mt/tauMu_2015_trigg_cfg.py
+++ b/CMGTools/H2TauTau/cfgPython/mt/tauMu_2015_trigg_cfg.py
@@ -1,0 +1,136 @@
+import PhysicsTools.HeppyCore.framework.config as cfg
+
+from CMGTools.H2TauTau.tauMu_2015_base_cfg import sequence
+from CMGTools.H2TauTau.htt_ntuple_base_cff import commonSequence
+
+from CMGTools.H2TauTau.proto.analyzers.H2TauTauTreeProducerTauMuTrigger import H2TauTauTreeProducerTauMuTrigger
+
+from PhysicsTools.HeppyCore.framework.config import printComps
+from PhysicsTools.HeppyCore.framework.heppy_loop import getHeppyOption
+
+from CMGTools.RootTools.utils.splitFactor import splitFactor
+from CMGTools.RootTools.samples.ComponentCreator import ComponentCreator
+from CMGTools.RootTools.samples.samples_13TeV_74X import TT_pow, DYJetsToLL_M50, WJetsToLNu, WJetsToLNu_HT100to200, WJetsToLNu_HT200to400, WJetsToLNu_HT400to600, WJetsToLNu_HT600toInf, QCD_Mu15, WWTo2L2Nu, ZZp8, WZp8, SingleTop
+from CMGTools.RootTools.samples.samples_13TeV_DATA2015 import SingleMuon_Run2015B_17Jul, SingleMuon_Run2015B
+from CMGTools.H2TauTau.proto.samples.spring15.triggers_tauMu import mc_triggers as mc_triggers_mt
+from CMGTools.H2TauTau.proto.samples.spring15.triggers_tauMu import data_triggers as data_triggers_mt
+from CMGTools.H2TauTau.proto.samples.spring15.higgs import HiggsGGH125, HiggsVBF125, HiggsTTH125
+
+from CMGTools.H2TauTau.htt_ntuple_base_cff import puFileData, puFileMC, eventSelector
+
+# Get all heppy options; set via "-o production" or "-o production=True"
+# production = True run on batch, production = False (or unset) run locally
+production = getHeppyOption('production')
+
+pick_events = True
+syncntuple = False
+
+creator = ComponentCreator()
+ggh160   = creator.makeMCComponent("GGH160" , "/SUSYGluGluToHToTauTau_M-160_TuneCUETP8M1_13TeV-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM", "CMS", ".*root", 1.0)
+qcd_flat = creator.makeMCComponent("QCDflat", "/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISpring15DR74-Asympt25nsRaw_MCRUN2_74_V9-v3/MINIAODSIM"    , "CMS", ".*root", 2022100000.)
+ggh125   = creator.makeMCComponent("GGH125" , "/GluGluHToTauTau_M125_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM"             , "CMS", ".*root", 1.0)
+
+# samples = [qcd_flat, TT_pow, DYJetsToLL_M50, WJetsToLNu, WJetsToLNu_HT100to200, WJetsToLNu_HT200to400, WJetsToLNu_HT400to600, WJetsToLNu_HT600toInf]
+# samples = [TT_pow, DYJetsToLL_M50, WJetsToLNu, QCD_Mu15, WWTo2L2Nu, ZZp8, WZp8]
+# samples = [HiggsGGH125, HiggsVBF125, HiggsTTH125] + SingleTop
+
+samples = [ggh125]
+
+split_factor = 1e5
+
+for sample in samples:
+    sample.triggers = ['HLT_IsoMu24_eta2p1_v1'] #mc_triggers_mt
+    sample.splitFactor = splitFactor(sample, split_factor)
+
+data_list = [SingleMuon_Run2015B_17Jul, SingleMuon_Run2015B]
+
+for sample in data_list:
+    sample.triggers = data_triggers_mt
+    sample.splitFactor = splitFactor(sample, split_factor)
+    sample.json = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_246908-251883_13TeV_PromptReco_Collisions15_JSON_v2.txt'
+    sample.lumi = 40.03
+
+
+###################################################
+###              ASSIGN PU to MC                ###
+###################################################
+for mc in samples:
+    mc.puFileData = puFileData
+    mc.puFileMC = puFileMC
+
+###################################################
+###             SET COMPONENTS BY HAND          ###
+###################################################
+# selectedComponents = samples + data_list
+# selectedComponents = data_list
+selectedComponents = samples
+
+
+###################################################
+###        AD HOC TRIGGER TREE PRODUCER         ###
+###################################################
+treeProducer = cfg.Analyzer(
+    H2TauTauTreeProducerTauMuTrigger,
+    name='H2TauTauTreeProducerTauMuTrigger'
+)
+
+###################################################
+###             CHERRY PICK EVENTS              ###
+###################################################
+
+if pick_events:
+    eventSelector.toSelect = [178036, 1254835, 227759, 1290544, 228758, 214782, 752109, 1279542, 1448477, 767598, 735715, 738503, 1422548, 534428]
+    sequence.insert(0, eventSelector)
+
+if not syncntuple:
+    module = [s for s in sequence if s.name == 'H2TauTauSyncTreeProducerTauMu'][0]
+    sequence.remove(module)
+
+###################################################
+###            SET BATCH OR LOCAL               ###
+###################################################
+if not production:
+    cache = True
+    # comp = my_connect.mc_dict['HiggsSUSYGG160']
+    # selectedComponents = [comp]
+    # comp = selectedComponents[0]
+    # comp = data_list[0]
+    #comp = QCD_Mu15
+    comp = ggh125
+    selectedComponents = [comp]
+    comp.splitFactor = 1
+    comp.fineSplitFactor = 1
+    # comp.files = comp.files[]
+
+###################################################
+###                  SEQUENCE                   ###
+###################################################
+# Adding specific mutau analyzers to the sequence
+for i, module in enumerate(sequence):
+  
+    if module.name == 'TriggerAnalyzer':
+        module.requireTrigger = True
+        module.extraTrig = ['HLT_DoubleMediumIsoPFTau40_Trk1_eta2p1_Reg_v1']
+        # module.verbose = False
+        module.saveFlag = True
+    
+    if module.name == 'H2TauTauTreeProducerTauMu':
+        sequence.insert(i, treeProducer)
+        del sequence[i+1]
+
+print sequence
+
+# the following is declared in case this cfg is used in input to the
+# heppy.py script
+from PhysicsTools.HeppyCore.framework.eventsfwlite import Events
+config = cfg.Config(components=selectedComponents,
+                    sequence=sequence,
+                    services=[],
+                    events_class=Events
+                    )
+
+printComps(config.components, True)
+
+def modCfgForPlot(config):
+    config.components = []
+

--- a/CMGTools/H2TauTau/python/proto/analyzers/DiLeptonAnalyzer.py
+++ b/CMGTools/H2TauTau/python/proto/analyzers/DiLeptonAnalyzer.py
@@ -318,7 +318,7 @@ class DiLeptonAnalyzer(Analyzer):
         to.matched = False
         for leg in legs:
             # JAN - Single-ele trigger filter has pdg ID 0, to be understood
-            # RIC - same seems to happen with di-tau
+            # RIC - same seems to happen with di-tau and mu + tau monitoring 
             if pdgId == abs(leg.pdgId()) or \
                (pdgId == 0 and abs(leg.pdgId()) == 11) or \
                (pdgId == 0 and abs(leg.pdgId()) == 15):

--- a/CMGTools/H2TauTau/python/proto/analyzers/H2TauTauTreeProducerTauMu.py
+++ b/CMGTools/H2TauTau/python/proto/analyzers/H2TauTauTreeProducerTauMu.py
@@ -40,6 +40,10 @@ class H2TauTauTreeProducerTauMu(H2TauTauTreeProducer):
             self.var(self.tree, 'l1_mini_iso')
             self.var(self.tree, 'l1_mini_reliso')
 
+        if hasattr(self.cfg_ana, 'addTnPInfo') and self.cfg_ana.addTnPInfo:
+            self.var(self.tree, 'tag')
+            self.var(self.tree, 'probe')
+
     def process(self, event):
 
         super(H2TauTauTreeProducerTauMu, self).process(event)
@@ -79,5 +83,9 @@ class H2TauTauTreeProducerTauMu(H2TauTauTreeProducer):
             self.fill(self.tree, 'l2_puppi_iso03_pt', tau.puppi_iso03_pt)
             self.fill(self.tree, 'l1_mini_iso', muon.miniAbsIso)
             self.fill(self.tree, 'l1_mini_reliso', muon.miniRelIso)
+
+        if hasattr(self.cfg_ana, 'addTnPInfo') and self.cfg_ana.addTnPInfo:
+            self.fill(self.tree, 'tag', event.tag)
+            self.fill(self.tree, 'probe', event.probe)
 
         self.fillTree(event)

--- a/CMGTools/H2TauTau/scripts/triggerEfficiency.py
+++ b/CMGTools/H2TauTau/scripts/triggerEfficiency.py
@@ -1,0 +1,82 @@
+#!/bin/env python
+
+import argparse
+import ROOT
+import numpy as np
+
+parser = argparse.ArgumentParser(description = 'Trigger tun-ons fitter. Pass me the ntuple location and a bunch of options')
+
+parser.add_argument('ntuplePath', type = str, nargs = 1, help = 'path to the ntuple')
+parser.add_argument('-t', '--tree', type = str, default = 'tree', help = 'name of the tree')
+parser.add_argument('-s', '--selection', type = list, default = ['tag > 0',
+                                                                'l2_byCombinedIsolationDeltaBetaCorr3Hits < 2.', 
+                                                                'l1_charge * l2_charge < 0.',
+                                                                'l2_eta < 2.3',
+                                                                'l2_eta > -2.3',
+                                                                'l2_pt > 20'], help = 'offline selection')
+parser.add_argument('-b', '--binning', default = [0., 10., 15., 20., 25., 30., 35., 40., 50., 70., 100., 200.], help = 'binning')
+parser.add_argument('-f', '--doFit', action = 'store_true', help = 'perform the fit')
+parser.add_argument('-r', '--fitRange', default = [20., 200.], help = 'fit range')
+parser.add_argument('-F', '--fitFunction', default = '[0]*TMath::Erf((x-[1])/[2])', help = 'define the function to be used in the fit')
+parser.add_argument('-p', '--initialParameters', type = list, default = [(0, .8), (1, 20.), (2, 10.)], help = 'initial parameters of the fit')
+parser.add_argument('-o', '--saveOutput', default = '', help = 'pass name of the root file where the efficiency TH1 is to be saved. If left blank no file is saved')
+
+args = parser.parse_args()
+
+fileName  = args.ntuplePath[0]
+selection = args.selection
+treeName  = args.tree
+
+ROOT.TH1.SetDefaultSumw2()
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(False)
+
+f1 = ROOT.TFile.Open(fileName)
+f1.cd()
+t1 = f1.Get(treeName)
+
+bins = np.array(args.binning)
+
+h_den = ROOT.TH1F('h_den', 'h_den', len(bins)-1, bins)
+h_num = ROOT.TH1F('h_num', 'h_num', len(bins)-1, bins)
+
+sel_den = ' && '.join(selection)
+sel_num = sel_den + '&& probe > 0'
+
+t1.Draw('l2_pt>>h_den', sel_den)
+t1.Draw('l2_pt>>h_num', sel_num)
+
+c1 = ROOT.TCanvas('', '', 700, 700)
+
+ROOT.gPad.SetGridx()
+ROOT.gPad.SetGridy()
+
+h_num.Divide(h_den)
+h_num.GetXaxis().SetTitle('offline #tau p_{T} [GeV]')
+h_num.GetYaxis().SetTitle('L1 + HLT efficiency')
+h_num.GetXaxis().SetTitleOffset(1.3)
+h_num.GetYaxis().SetTitleOffset(1.3)
+h_num.SetTitle('')
+h_num.SetMarkerStyle(8)
+h_num.SetLineWidth(2)
+h_num.Draw('E')
+
+if args.doFit:
+    func = ROOT.TF1('func', args.fitFunction, args.fitRange[0], args.fitRange[1])
+    for pair in args.initialParameters:
+        func.SetParameter(pair[0], pair[1])
+
+    h_num.Fit('func')
+    func.Draw('SAME')
+
+c1.SaveAs('eff.pdf')
+
+if len(args.saveOutput):
+    o1 = ROOT.TFile(args.saveOutput, 'recreate')
+    o1.cd()
+    h_num.Write()
+    c1.Write()
+    o1.Close()
+    
+
+


### PR DESCRIPTION
- add an ad hoc cfg to produce tuples that contain two additional branches: tag and probe
- minor modifications to TriggerAnalyzer: now handles extra triggers (the triggers to probe) that are not used to select events, but a flag is set to true in case any of these triggers is fired. 
- trigger matching to offline objects comes at no cost, if only the tag trigger is fired, e.g. single mu, only the muon is matched, if also to probe trigger is fired, e.g. mu + tau both the muon and the taus must be matched. DiLeptonAnalyzer is left untouched.
- add simple script to plot efficiencies ad fit turn ons from the tuples produced this way
